### PR TITLE
Added support for push to interact delay for press instead of hold text

### DIFF
--- a/lua/HUDManagerPD2.lua
+++ b/lua/HUDManagerPD2.lua
@@ -281,7 +281,7 @@ function HUDManager.show_interact(self, data)
 		return
 	end
 
-	if SydneyHUD:GetOption("push_to_interact") then
+	if SydneyHUD:GetOption("push_to_interact") and managers.player:toolset_value() >= SydneyHUD:GetOption("push_to_interact_delay")  then
 		data.text = HUDManager:press_substitute(data.text, "Press")
 	end
 


### PR DESCRIPTION
Currently only shows press if the delay is set to less than 1
Needs to get the correct timer value so it only shows press when the conditions are meet